### PR TITLE
Feature: add inner text / html support

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,22 +183,22 @@
 			};
 
 			/**
-				*  Remove root tag from html (helper taken from RichText code)
-				*  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L291
-				*/
+			*  Remove root tag from html (helper taken from RichText code)
+			*  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L291
+			*/
 			const removeRootTag = ( tag, html ) => {
-					const openingTagRegexp = RegExp( '^<' + tag + '[^>]*>', 'gim' );
-					const closingTagRegexp = RegExp( '</' + tag + '>$', 'gim' );
+				const openingTagRegexp = RegExp( '^<' + tag + '[^>]*>', 'gim' );
+				const closingTagRegexp = RegExp( '</' + tag + '>$', 'gim' );
 
-					return html
-						.replace( openingTagRegexp, '' )
-						.replace( closingTagRegexp, '' );
+				return html
+					.replace( openingTagRegexp, '' )
+					.replace( closingTagRegexp, '' );
 			}
 
 			/**
-				*  Remove specific tag from html (helper taken from RichText code)
-				*  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L300
-				*/
+			*  Remove specific tag from html (helper taken from RichText code)
+			*  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L300
+			*/
 			const removeTag = ( tag, html ) => {
 				const openingTagRegexp = RegExp( '<' + tag + '>', 'gim' );
 				const closingTagRegexp = RegExp( '</' + tag + '>', 'gim' );

--- a/index.html
+++ b/index.html
@@ -130,16 +130,45 @@
 			const parseBlock = (block) => {
 
 				// Add support for RichText
-				const innerHTML = block?.innerHTML;
+				let innerHTML = block?.innerHTML;
 				const innerBlocks = block?.innerBlocks;
 				let innerContentAttr = block.blockName === 'core/button' ? 'text' : 'content';
+
+                // Ideally we should get those infos from each block.json but we hardcode it for simplicity
+                let blockTagNames = '';
+                switch (block.blockName) {
+                    case 'core/heading':
+                        blockTagNames = 'h1,h2,h3,h4,h5,h6';
+                        break;
+
+                    case 'core/paragraph':
+                        blockTagNames = 'p';
+                        break;
+
+                    case 'core/button':
+                        blockTagNames = 'div,a';
+                        break;
+                
+                    default:
+                        break;
+                }
+                const unAllowedTags = [
+                    'div',
+                    'script',
+                    'style',
+                ];
 
 				// Add content only if there is no innerBlocks & some innerHTML
 				if (innerHTML && !innerBlocks?.length) {
 
-					// only innerText is needed
-					const innerText = new DOMParser().parseFromString(innerHTML, "text/html").body.textContent || "";
-					block.attrs[ innerContentAttr ] = innerText;
+                    // Remove root tags from blocks
+                    const blockTags = blockTagNames.split(',');
+                    blockTags.map(tag => innerHTML = removeRootTag(tag, innerHTML));
+                    
+                    // Remove unallowed tags
+                    unAllowedTags.forEach(tag => innerHTML = removeTag(tag, innerHTML));
+
+					block.attrs[ innerContentAttr ] = innerHTML;
 				}
 
 				let data = `['${block.blockName}',${JSON.stringify(block.attrs, null, "")},[`;
@@ -152,6 +181,32 @@
 
 				return data;
 			};
+
+            /**
+             *  Remove root tag from html (helper taken from RichText code)
+             *  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L291
+             */
+            const removeRootTag = ( tag, html ) => {
+                    const openingTagRegexp = RegExp( '^<' + tag + '[^>]*>', 'gim' );
+                    const closingTagRegexp = RegExp( '</' + tag + '>$', 'gim' );
+
+                    return html
+                        .replace( openingTagRegexp, '' )
+                        .replace( closingTagRegexp, '' );
+            }
+
+            /**
+             *  Remove specific tag from html (helper taken from RichText code)
+             *  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L300
+             */
+            const removeTag = ( tag, html ) => {
+                const openingTagRegexp = RegExp( '<' + tag + '>', 'gim' );
+                const closingTagRegexp = RegExp( '</' + tag + '>', 'gim' );
+
+                return html
+                    .replace( openingTagRegexp, '' )
+                    .replace( closingTagRegexp, '' );
+            }
 
 			/**
 			 * Convert WPHTML from the page's textarea into a string representation of

--- a/index.html
+++ b/index.html
@@ -129,19 +129,19 @@
 			 */
 			const parseBlock = (block) => {
 
-                // Add support for RichText
-                const innerHTML = block?.innerHTML;
-                const innerBlocks = block?.innerBlocks;
-                let innerContentAttr = block.blockName === 'core/button' ? 'text' : 'content';
+				// Add support for RichText
+				const innerHTML = block?.innerHTML;
+				const innerBlocks = block?.innerBlocks;
+				let innerContentAttr = block.blockName === 'core/button' ? 'text' : 'content';
 
-                // Add content only if there is no innerBlocks & some innerHTML
-                if ( innerHTML && !innerBlocks?.length ) {
+				// Add content only if there is no innerBlocks & some innerHTML
+				if (innerHTML && !innerBlocks?.length) {
 
-                    // only innerText is needed
-                    const innerText = new DOMParser().parseFromString(innerHTML, "text/html").body.textContent || "";
-                    block.attrs[innerContentAttr] = innerText;
-                }
-                
+					// only innerText is needed
+					const innerText = new DOMParser().parseFromString(innerHTML, "text/html").body.textContent || "";
+					block.attrs[ innerContentAttr ] = innerText;
+				}
+
 				let data = `['${block.blockName}',${JSON.stringify(block.attrs, null, "")},[`;
 
 				block.innerBlocks?.forEach((innerBlock) => {

--- a/index.html
+++ b/index.html
@@ -128,6 +128,20 @@
 			 * @returns {string}
 			 */
 			const parseBlock = (block) => {
+
+                // Add support for RichText
+                const innerHTML = block?.innerHTML;
+                const innerBlocks = block?.innerBlocks;
+                let innerContentAttr = block.blockName === 'core/button' ? 'text' : 'content';
+
+                // Add content only if there is no innerBlocks & some innerHTML
+                if ( innerHTML && !innerBlocks?.length ) {
+
+                    // only innerText is needed
+                    const innerText = new DOMParser().parseFromString(innerHTML, "text/html").body.textContent || "";
+                    block.attrs[innerContentAttr] = innerText;
+                }
+                
 				let data = `['${block.blockName}',${JSON.stringify(block.attrs, null, "")},[`;
 
 				block.innerBlocks?.forEach((innerBlock) => {

--- a/index.html
+++ b/index.html
@@ -134,39 +134,39 @@
 				const innerBlocks = block?.innerBlocks;
 				let innerContentAttr = block.blockName === 'core/button' ? 'text' : 'content';
 
-                // Ideally we should get those infos from each block.json but we hardcode it for simplicity
-                let blockTagNames = '';
-                switch (block.blockName) {
-                    case 'core/heading':
-                        blockTagNames = 'h1,h2,h3,h4,h5,h6';
-                        break;
+				// Ideally we should get those infos from each block.json but we hardcode it for simplicity
+				let blockTagNames = '';
+				switch (block.blockName) {
+					case 'core/heading':
+						blockTagNames = 'h1,h2,h3,h4,h5,h6';
+						break;
 
-                    case 'core/paragraph':
-                        blockTagNames = 'p';
-                        break;
+					case 'core/paragraph':
+						blockTagNames = 'p';
+						break;
 
-                    case 'core/button':
-                        blockTagNames = 'div,a';
-                        break;
-                
-                    default:
-                        break;
-                }
-                const unAllowedTags = [
-                    'div',
-                    'script',
-                    'style',
-                ];
+					case 'core/button':
+						blockTagNames = 'div,a';
+						break;
+				
+					default:
+						break;
+				}
+				const unAllowedTags = [
+					'div',
+					'script',
+					'style',
+				];
 
 				// Add content only if there is no innerBlocks & some innerHTML
 				if (innerHTML && !innerBlocks?.length) {
 
-                    // Remove root tags from blocks
-                    const blockTags = blockTagNames.split(',');
-                    blockTags.map(tag => innerHTML = removeRootTag(tag, innerHTML));
-                    
-                    // Remove unallowed tags
-                    unAllowedTags.forEach(tag => innerHTML = removeTag(tag, innerHTML));
+					// Remove root tags from blocks
+					const blockTags = blockTagNames.split(',');
+					blockTags.map(tag => innerHTML = removeRootTag(tag, innerHTML));
+					
+					// Remove unallowed tags
+					unAllowedTags.forEach(tag => innerHTML = removeTag(tag, innerHTML));
 
 					block.attrs[ innerContentAttr ] = innerHTML;
 				}
@@ -182,31 +182,31 @@
 				return data;
 			};
 
-            /**
-             *  Remove root tag from html (helper taken from RichText code)
-             *  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L291
-             */
-            const removeRootTag = ( tag, html ) => {
-                    const openingTagRegexp = RegExp( '^<' + tag + '[^>]*>', 'gim' );
-                    const closingTagRegexp = RegExp( '</' + tag + '>$', 'gim' );
+			/**
+				*  Remove root tag from html (helper taken from RichText code)
+				*  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L291
+				*/
+			const removeRootTag = ( tag, html ) => {
+					const openingTagRegexp = RegExp( '^<' + tag + '[^>]*>', 'gim' );
+					const closingTagRegexp = RegExp( '</' + tag + '>$', 'gim' );
 
-                    return html
-                        .replace( openingTagRegexp, '' )
-                        .replace( closingTagRegexp, '' );
-            }
+					return html
+						.replace( openingTagRegexp, '' )
+						.replace( closingTagRegexp, '' );
+			}
 
-            /**
-             *  Remove specific tag from html (helper taken from RichText code)
-             *  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L300
-             */
-            const removeTag = ( tag, html ) => {
-                const openingTagRegexp = RegExp( '<' + tag + '>', 'gim' );
-                const closingTagRegexp = RegExp( '</' + tag + '>', 'gim' );
+			/**
+				*  Remove specific tag from html (helper taken from RichText code)
+				*  @link https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L300
+				*/
+			const removeTag = ( tag, html ) => {
+				const openingTagRegexp = RegExp( '<' + tag + '>', 'gim' );
+				const closingTagRegexp = RegExp( '</' + tag + '>', 'gim' );
 
-                return html
-                    .replace( openingTagRegexp, '' )
-                    .replace( closingTagRegexp, '' );
-            }
+				return html
+					.replace( openingTagRegexp, '' )
+					.replace( closingTagRegexp, '' );
+			}
 
 			/**
 			 * Convert WPHTML from the page's textarea into a string representation of


### PR DESCRIPTION
## Feature
This adds support for `content` & `text` attribute used by most low-level blocks _(like heading, paragraph, button...)_ and so it keeps content inside them _(some html tags are filtered, [like RichText component does it](https://github.com/WordPress/gutenberg/blob/32a90263edaa9f6e6f0a9675722febeb2055143a/packages/block-editor/src/components/rich-text/native/index.native.js#L275-L306))_.

It fixes this issue: #5 , it lacks some features still _(like button link...)_ but still better than nothing

## Test
Used this HTML gutenberg code to test the feature:
```html
<!-- wp:heading -->
<h2 class="wp-block-heading">Default title</h2>
<!-- /wp:heading -->

<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">H3 title</h3>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Paragraph text</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><strong>Bold paragraph text</strong></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><em>Italic text</em></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><s>Strikethrough text</s></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><code>Code text</code></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><sup>Superscript text</sup></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><sub>Subscript text</sub></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><mark style="background-color:var(--wp--custom--color--primary--vert-macif)" class="has-inline-color has-contrast-color">Highlight text</mark></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><a href="#link">Link text</a></p>
<!-- /wp:paragraph -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#button-link">Button text</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

## Result
Works for both PHP formatting and JS formatting:
### _Before:_  
![happyprime github io_wphtml-converter_](https://github.com/happyprime/wphtml-converter/assets/6544224/8002785b-ccae-4b21-97e1-42c7fec034fe)

### _After:_
![127 0 0 1_5500_index html](https://github.com/happyprime/wphtml-converter/assets/6544224/2f24d01d-5735-447f-bd1a-feb31cf7e503)

